### PR TITLE
Fix throw error when Jaeger is disabled for testing purposes

### DIFF
--- a/src/decorators/decorators_ts.ts
+++ b/src/decorators/decorators_ts.ts
@@ -107,6 +107,13 @@ export function TraceableMethodDecorator(target: object, propertyKey: string, de
     const data: IMetadataTracer = Reflect.getMetadata(METADATA_KEY.CLASS_TRACER, this);
     const tracer = Reflect.getMetadata(METADATA_KEY.GLOBAL_TRACER, JaegerTracer);
     if (!tracer) {
+      if (/test[s]?/.test(process.env.NODE_ENV?.toLowerCase() ?? '')) {
+        try {
+          return originalMethod.apply(this, args);
+        } catch (e) {
+          throw e;
+        }
+      }
       throw new Error(ERROR_MSG.TRACER_NOT_INITIALIZE);
     }
 


### PR DESCRIPTION
In projects that use Jaeger and Jest when running the tests the Jaeger process prevents Jest from finishing the tests. To prevent this from happening, you can disable Jaeger with `JAEGER_DISABLED` in test environment. But the decorator throws an error when Jaeger is not initialized.
The change is so that in test environments, if it doesn't find Jaeger, it continues executing the method normally.